### PR TITLE
Update ort to v2.0.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,23 +450,22 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e45a172e6c0fb7d640e92c7740f4ea476bfc49ef5c52ea9c73e9fae32b09fe"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
 dependencies = [
  "half",
  "libloading",
  "ndarray",
  "ort-sys",
- "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6fe264a9467cd0c19cbee07afe689fae9480c4706c4a1a00b5e64ff99ea83a"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -720,26 +719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,19 +740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Speaker diarization using pyannote in Rust"
 eyre = "0.6.12"
 hound = "3.5.1"
 ndarray = "0.16"
-ort = "2.0.0-rc.5"
+ort = "2.0.0-rc.9"
 knf-rs = { version = "0.2.4", features = [] }
 
 [features]

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -1,7 +1,7 @@
 use crate::session;
 use eyre::{Context, ContextCompat, Result};
 use ndarray::Array2;
-use ort::Session;
+use ort::session::Session;
 use std::path::Path;
 
 #[derive(Debug)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use eyre::Result;
-use ort::{GraphOptimizationLevel, Session};
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
 
 pub fn create_session<P: AsRef<Path>>(path: P) -> Result<Session> {
     let session = Session::builder()?


### PR DESCRIPTION
Following ort's 2.0.0-rc.9 "[Undo The Flattening](https://github.com/pykeio/ort/releases)" change, update import paths:  
- Move from flat `ort::Session` to `ort::session::Session`
- Move from flat `ort::GraphOptimizationLevel` to `ort::session::builder::GraphOptimizationLevel` 