### PR TITLE
Include the "repository" field in the cargo manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0-beta.0"
 edition = "2021"
 license = "MIT"
 description = "Speaker diarization using pyannote in Rust"
+repository = "https://github.com/thewh1teagle/pyannote-rs"
 
 [dependencies]
 eyre = "0.6.12"

--- a/crates/knf-rs/Cargo.toml
+++ b/crates/knf-rs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0-beta.0"
 edition = "2021"
 license = "MIT"
 description = "fbank features extractor without external dependencies"
+repository = "https://github.com/thewh1teagle/pyannote-rs"
 
 [dependencies]
 knf-rs-sys = { path = "sys", version = "0.3.0-beta.0", features = [] }

--- a/crates/knf-rs/sys/Cargo.toml
+++ b/crates/knf-rs/sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0-beta.0"
 edition = "2021"
 license = "MIT"
 description = "fbank features extractor without external dependencies"
+repository = "https://github.com/thewh1teagle/pyannote-rs"
 
 include = [
     "knfc",


### PR DESCRIPTION
Hi and thanks for Rust impl of the pyannote!

I've got hard time trying to find this repo from `crates.io`, so I think it's worth mentioning this repository in `Cargo.toml`s.

If you also think so please consider this PR and maybe push the updated crates to the `crates.io` :)

Thanks!