### PR TITLE
Invert session dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 target/
 build/
 *.onnx

--- a/examples/infinite.rs
+++ b/examples/infinite.rs
@@ -5,7 +5,7 @@ wget https://github.com/thewh1teagle/pyannote-rs/releases/download/v0.1.0/6_spea
 cargo run --example infinite 6_speakers.wav
 */
 
-use pyannote_rs::{EmbeddingExtractor, EmbeddingManager};
+use pyannote_rs::{create_session, EmbeddingExtractor, EmbeddingManager};
 
 fn process_segment(
     segment: pyannote_rs::Segment,
@@ -42,8 +42,9 @@ fn main() -> Result<(), eyre::Report> {
     let (samples, sample_rate) = pyannote_rs::read_wav(&audio_path)?;
     let mut embedding_extractor = EmbeddingExtractor::new(embedding_model_path)?;
     let mut embedding_manager = EmbeddingManager::new(usize::MAX);
+    let mut session = create_session(segmentation_model_path)?;
 
-    let segments = pyannote_rs::get_segments(&samples, sample_rate, segmentation_model_path)?;
+    let segments = pyannote_rs::get_segments(&samples, sample_rate, &mut session)?;
 
     for segment in segments {
         if let Ok(segment) = segment {

--- a/examples/max_speakers.rs
+++ b/examples/max_speakers.rs
@@ -1,15 +1,16 @@
-use pyannote_rs::{EmbeddingExtractor, EmbeddingManager};
+use pyannote_rs::{create_session, EmbeddingExtractor, EmbeddingManager};
 
-fn main() {
+fn main() -> Result<(), eyre::Report> {
     let audio_path = std::env::args().nth(1).expect("Please specify audio file");
-    let (samples, sample_rate) = pyannote_rs::read_wav(&audio_path).unwrap();
+    let (samples, sample_rate) = pyannote_rs::read_wav(&audio_path)?;
     let max_speakers = 6;
 
-    let mut extractor = EmbeddingExtractor::new("wespeaker_en_voxceleb_CAM++.onnx").unwrap();
+    let mut extractor = EmbeddingExtractor::new("wespeaker_en_voxceleb_CAM++.onnx")?;
     let mut manager = EmbeddingManager::new(6);
 
-    let segments =
-        pyannote_rs::get_segments(&samples, sample_rate, "segmentation-3.0.onnx").unwrap();
+    let mut session = create_session("segmentation-3.0.onnx")?;
+
+    let segments = pyannote_rs::get_segments(&samples, sample_rate, &mut session)?;
 
     for segment in segments {
         match segment {
@@ -40,4 +41,6 @@ fn main() {
             Err(error) => eprintln!("Failed to process segment: {:?}", error),
         }
     }
+
+    Ok(())
 }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -15,6 +15,10 @@ impl EmbeddingExtractor {
         Ok(Self { session })
     }
 
+    pub fn from(session: Session) -> Result<Self> {
+        Ok(Self { session })
+    }
+
     pub fn compute(&mut self, samples: &[i16]) -> Result<impl Iterator<Item = f32>> {
         // Convert to f32 precisely
         let mut samples_f32 = vec![0.0; samples.len()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
-mod session;
-
 mod embedding;
 mod identify;
 mod segment;
+mod session;
 mod wav;
 
 pub use embedding::EmbeddingExtractor;
 pub use identify::EmbeddingManager;
 pub use knf_rs::{compute_fbank, convert_integer_to_float_audio};
 pub use segment::{get_segments, Segment};
+pub use session::create_session;
 pub use wav::read_wav;

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,7 +1,7 @@
-use crate::session;
 use eyre::{Context, ContextCompat, Result};
 use ndarray::{ArrayBase, Axis, IxDyn, ViewRepr};
-use std::{cmp::Ordering, collections::VecDeque, path::Path};
+use ort::session::Session;
+use std::{cmp::Ordering, collections::VecDeque};
 
 #[derive(Debug, Clone)]
 #[repr(C)]
@@ -24,14 +24,11 @@ fn find_max_index(row: ArrayBase<ViewRepr<&f32>, IxDyn>) -> Result<usize> {
     Ok(max_index)
 }
 
-pub fn get_segments<P: AsRef<Path>>(
-    samples: &[i16],
+pub fn get_segments<'a>(
+    samples: &'a [i16],
     sample_rate: u32,
-    model_path: P,
-) -> Result<impl Iterator<Item = Result<Segment>> + '_> {
-    // Create session using the provided model path
-    let mut session = session::create_session(model_path.as_ref())?;
-
+    session: &'a mut Session,
+) -> Result<impl Iterator<Item = Result<Segment>> + 'a> {
     // Define frame parameters
     let frame_size = 270;
     let frame_start = 721;


### PR DESCRIPTION
# Summary

Currently, the `create_session` function not exposed, which makes it impossible to create a session with custom parameters. For example, in our use case we rely on:
```rust
.with_execution_providers(vec![CUDAExecutionProvider::default().build()])
.commit_from_memory(model)
```

Additionally, `EmbeddingExtractor` and the `get_segments` function are tightly coupled, which limits flexibility and extensibility.

## Proposed Changes

This PR inverts the dependency on `create_session`, allowing users to customize session creation as needed.
As a result, this introduces a minor breaking change to the API. You can refer to the updated usage example to see the adjusted way to initialize and use the library.

## Notes

Open to discussion and feedback especially regarding the API design and how to best preserve backward compatibility.